### PR TITLE
Remove useless call to setCancelJobOnError

### DIFF
--- a/matlab/matlab-middleman/src/main/java/org/ow2/proactive/scheduler/ext/matlab/middleman/AOMatlabEnvironment.java
+++ b/matlab/matlab-middleman/src/main/java/org/ow2/proactive/scheduler/ext/matlab/middleman/AOMatlabEnvironment.java
@@ -222,7 +222,6 @@ public class AOMatlabEnvironment extends AOMatSciEnvironment<Boolean, MatlabResu
             TaskFlowJob job = new TaskFlowJob();
             job.setName(gconf.getJobName() + " " + lastGenJobId++);
             job.setPriority(JobPriority.findPriority(config.getPriority()));
-            job.setCancelJobOnError(false);
             job.setDescription(gconf.getJobDescription());
 
             String pullUrl = config.getSharedPullPublicUrl();

--- a/scilab/scilab-middleman/src/main/java/org/ow2/proactive/scheduler/ext/scilab/middleman/AOScilabEnvironment.java
+++ b/scilab/scilab-middleman/src/main/java/org/ow2/proactive/scheduler/ext/scilab/middleman/AOScilabEnvironment.java
@@ -215,7 +215,6 @@ public class AOScilabEnvironment extends AOMatSciEnvironment<Boolean, ScilabResu
             TaskFlowJob job = new TaskFlowJob();
             job.setName(gconf.getJobName() + " " + lastGenJobId++);
             job.setPriority(JobPriority.findPriority(config.getPriority()));
-            job.setCancelJobOnError(false);
             job.setDescription(gconf.getJobDescription());
 
             String pullUrl = config.getSharedPullPublicUrl();


### PR DESCRIPTION
Besides, the method has been removed from the API, thus it was required to
remove the call or to replace it to fix the compilation error.

The change is related to the new suspend task on error feature.