### PR TITLE
Support for Scilab 5.5 and more  

### DIFF
--- a/matlab/matlab-worker/src/main/java/org/ow2/proactive/scheduler/ext/matlab/worker/MatlabExecutable.java
+++ b/matlab/matlab-worker/src/main/java/org/ow2/proactive/scheduler/ext/matlab/worker/MatlabExecutable.java
@@ -163,21 +163,7 @@ public class MatlabExecutable extends JavaExecutable {
         if (this.script == null || "".equals(this.script)) {
             throw new IllegalArgumentException("Unable to execute task, no script specified");
         }
-    }
 
-    @Override
-    public Serializable execute(final TaskResult... results) throws Throwable {
-        if (results != null) {
-            for (TaskResult res : results) {
-                if (res.hadException()) {
-                    throw res.getException();
-                }
-            }
-        }
-        if (paconfig.isDebug()) {
-            ProActiveLogger.getLogger(MatlabExecutable.class).setLevel(Level.DEBUG);
-        }
-        
         // Initialize MATLAB location
         this.initMatlabConfig();
 
@@ -189,6 +175,21 @@ public class MatlabExecutable extends JavaExecutable {
         this.initTransferEnv();
         this.initTransferInputFiles();
         this.initTransferVariables();
+    }
+
+    @Override
+    public Serializable execute(final TaskResult... results) throws Throwable {
+        if (results != null) {
+            for (TaskResult res : results) {
+                if (res.hadException()) {
+                    throw res.getException();
+                }
+            }
+        }
+
+        if (paconfig.isDebug()) {
+            ProActiveLogger.getLogger(MatlabExecutable.class).setLevel(Level.DEBUG);
+        }
 
         final String matlabCmd = this.matlabEngineConfig.getFullCommand();
         this.printLog("Acquiring MATLAB connection using " + matlabCmd);

--- a/scilab/scilab-client/src/scilab/builder.sce
+++ b/scilab/scilab-client/src/scilab/builder.sce
@@ -6,18 +6,10 @@ TOOLBOX_NAME = 'ProActiveConnector';
 TOOLBOX_TITLE = 'ProActive Connector';
 
 // Version Check
-try
-    version = getversion('scilab');
-    if version(1) < 5
-        error(gettext('Scilab 5.3.3 or more is required.'));
-    elseif version(1) == 5 & version(2) < 3
-        error(gettext('Scilab 5.3.3 or more is required.'));
-    elseif version(1) == 5 & version(2) == 3 & version(3) < 3
-        error(gettext('Scilab 5.3.3 or more is required.'));
-    end
-catch
-    error(gettext('Scilab 5.3.3 or more is required.'));
-end;
+version = getversion('scilab');
+if version(1) < 5 | (version(1) = 5 & version(2) < 5)
+	error(gettext('Scilab 5.5.0 or more is required.'));
+end
 
 disp('Build ProActive');
 

--- a/scilab/scilab-client/src/scilab/etc/ProActiveConnector.start
+++ b/scilab/scilab-client/src/scilab/etc/ProActiveConnector.start
@@ -7,13 +7,7 @@ function ProActiveConnectorlib = startModule()
      if isdef("ProActiveConnectorlib") then
             warning("ProActiveConnector library is already loaded");
             //return;
-        end
-
-        // JIMS install check
-        if ~atomsIsInstalled('JIMS')
-            error('JIMS Atoms Module must be installed in order to use ProActive Connector Module');
-        end
-
+     end
 
     etc_tlbx = get_absolute_file_path('ProActiveConnector.start');
     if ~exists('PA_matsci_dir') | PA_matsci_dir == []

--- a/scilab/scilab-client/src/scilab/macros/PAconnect.sci
+++ b/scilab/scilab-client/src/scilab/macros/PAconnect.sci
@@ -103,7 +103,7 @@ function deployJVM(opt,uri)
     addJavaObj(jarsjava);
     for i=1:size(jarfiles,1)
         jartmp = jnewInstance(String, jarfiles(i));
-        jarsjava(i-1) = jartmp;
+        jarsjava(i) = jartmp;
         addJavaObj(jartmp);
     end
     options = opt.JvmArguments;

--- a/scilab/scilab-client/src/scilab/macros/PAisAwaited.sci
+++ b/scilab/scilab-client/src/scilab/macros/PAisAwaited.sci
@@ -18,7 +18,7 @@ function tf=PAisAwaited(l)
         end
         answers = jinvoke(unrei,'get');
         for i=1:m
-            tf(i)=jinvoke(answers,'get', i-1);
+            tf(i)=answers(i);
         end        
         jremove(answers);
         jremove(unrei);

--- a/scilab/scilab-client/src/scilab/macros/PAsolve.sci
+++ b/scilab/scilab-client/src/scilab/macros/PAsolve.sci
@@ -45,7 +45,7 @@ function outputs = PAsolve(varargin)
             for j=1:MM
                 t_conf = jnewInstance(PASolveScilabTaskConfig);
                 addJavaObj(t_conf);
-                task_configs(i-1,j-1) = t_conf;
+                task_configs(i,j) = t_conf;
             end
         end
 
@@ -120,7 +120,7 @@ function outputs = PAsolve(varargin)
     taskinfo = struct('cleanDir',[], 'outFile',[], 'jobid',[], 'taskid',[] );
     results=list(NN);
     for i=1:NN
-        tidjava = jinvoke(ftnjava,'get',i-1);
+        tidjava = ftnjava(i);
         addJavaObj(tidjava);
         ftn(i) = string(tidjava);        
         taskinfo.cleanDir = dir_to_clean;
@@ -362,7 +362,7 @@ function taskFilesToClean = initTransferSource(task_configs,solve_config,opt,Tas
     jimport java.lang.String;
     for i=1:NN       
         for j=1:MM
-            t_conf = task_configs(i-1,j-1);
+            t_conf = task_configs(i,j);
             // Function
             Func = Tasks(j,i).Func;
             execstr(strcat(['functype = type(';Func;');']));
@@ -464,7 +464,7 @@ function initInputFiles(task_configs,solve_config,opt,Tasks,NN,MM)
     ddss = jnewInstance(DummyDSSource);
     for i=1:NN       
         for j=1:MM
-            t_conf = task_configs(i-1,j-1);
+            t_conf = task_configs(i,j);
             // Input Files
             ilen = size(Tasks(j,i).InputFiles);
                 if ilen > 0 then
@@ -495,7 +495,7 @@ function initOutputFiles(task_configs,solve_config,opt,Tasks,NN,MM)
     //addJavaObj(String);
     for i=1:NN       
         for j=1:MM
-            t_conf = task_configs(i-1,j-1);
+            t_conf = task_configs(i,j);
             // Output Files
                         ilen = size(Tasks(j,i).OutputFiles);
                             if ilen > 0 then
@@ -526,7 +526,7 @@ function [outVarFiles, inputscript, mainScript,taskFilesToClean] = initParameter
     curr_dir = pwd();
     for i=1:NN       
         for j=1:MM
-            t_conf = task_configs(i-1,j-1);
+            t_conf = task_configs(i,j);
             // Params
             argi = Tasks(j,i).Params;
             inVarFN = variableInFileBaseName + indToFile([i j]) + '.dat';
@@ -594,7 +594,7 @@ function initOtherTCAttributes(NN,MM, task_configs, Tasks)
     jimport java.net.URL;
     for i=1:NN       
         for j=1:MM
-            t_conf = task_configs(i-1,j-1);
+            t_conf = task_configs(i,j);
             if ~isempty(Tasks(j,i).Description) then
                 jinvoke(t_conf,'setDescription',Tasks(j,i).Description);
             end                        

--- a/scilab/scilab-worker/src/main/resources/ScilabWorkerConfiguration.xml
+++ b/scilab/scilab-worker/src/main/resources/ScilabWorkerConfiguration.xml
@@ -3,12 +3,12 @@
     <!-- This is an example Worker Configuration (Windows) -->
     <MachineGroup hostname=".*"> <!-- This is a regular expression representing the machines targeted by this configuration, attributes can either be "hostname" or "ip" -->
         <scilab>
-               <version>5.3.3</version>  <!-- The version of scilab (at least 5.3.0) -->
-               <home>/home/ybonnaffe/tools/scilab</home>  <!-- Scilab installation directory example on Windows,
+               <version>5.5.2</version>  <!-- The version of scilab -->
+               <home>C:\Program Files\scilab-5.5.2</home>  <!-- Scilab installation directory example on Windows,
                on linux, it's better to install it manually in a shared location than to use the packaging mechanism -->
                <bindir>bin</bindir> <!-- Scilab bin directory (should not be changed) -->
-               <command>scilab</command>  <!-- Scilab executable name -->
-               <arch>32</arch> <!-- Architecture 32 or 64 -->
+               <command>WScilex.exe</command>  <!-- Scilab executable name -->
+               <arch>64</arch> <!-- Architecture 32 or 64 -->
                <!-- Scilab executable name on linux : scilab , on windows: Scilex.exe -->
         </scilab>
     </MachineGroup>


### PR DESCRIPTION
- start indexes from 1 (not 0)
- remove JIMS check since it in now integrated in scilab and no more considered as an external module
- update scilab version check
- update comments in the xml properties file
- move initialization methods call in MatlabExecutable for compatibility with "Fix #264 Support for Scilab 5.5 and more " in scheduling project