### PR TITLE
Manually fix the serialver to exclude last digit of ProActive version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@
 programmingVersion=8.4.0-SNAPSHOT
 schedulingVersion=8.4.0-SNAPSHOT
 matsciVersion=8.4.0-SNAPSHOT
-matsciSerialver=840L
+matsciSerialver=84L


### PR DESCRIPTION
- The release process mistakenly included the maintenance version in the serial version UIDs. We fix this by applying manually the correct serial version UID for the next local builds. The automated version increase process is fixed separately for the future releases.